### PR TITLE
Se agrego un nuevo archivo llamado TaskRegister

### DIFF
--- a/Front/package-lock.json
+++ b/Front/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^5.0.3",
-        "vite": "^5.4.0"
+        "vite": "^5.4.20"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -553,6 +553,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "dev": true,
@@ -813,6 +828,8 @@
     },
     "node_modules/vite": {
       "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/Front/package.json
+++ b/Front/package.json
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^5.0.3",
-    "vite": "^5.4.0"
+    "vite": "^5.4.20"
   }
 }

--- a/Front/src/components/ProtectedRoute.jsx
+++ b/Front/src/components/ProtectedRoute.jsx
@@ -10,6 +10,12 @@ export default function ProtectedRoute() {
   if (loading) return <div style={{padding:24}}>Cargando…</div>
   if (!user) return <Navigate to="/login" replace state={{ from: location }} />
 
+   const path = location.pathname.replace(/^\/app\/?/, '')
+  const title = ({
+    'dashboard': 'Dashboard',
+    'tareas/registro': 'Registro de Tareas'
+  })[path] || 'Task Reward Pro'
+
   return (
     <div className="layout">
       <Sidebar />

--- a/Front/src/components/Sidebar.jsx
+++ b/Front/src/components/Sidebar.jsx
@@ -4,6 +4,14 @@ import { useAuth } from '../context/AuthContext.jsx'
 
 export default function Sidebar(){
   const { user, logout } = useAuth()
+  const link = (to, label) => (
+    <NavLink
+      to={to}
+      className={({isActive}) => 'navItem' + (isActive ? ' active' : '')}
+    >
+      {label}
+    </NavLink>
+  )
   return (
     <aside className="aside">
       <div className="brand">Task Reward Pro</div>

--- a/Front/src/pages/TaskRegister.jsx
+++ b/Front/src/pages/TaskRegister.jsx
@@ -1,0 +1,139 @@
+import React, { useEffect, useState } from 'react'
+import { createTask, listTasks } from '../services/api.js'
+
+export default function TaskRegister(){
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [dueDate, setDueDate] = useState('')
+  const [points, setPoints] = useState(10)
+  const [files, setFiles] = useState([])
+  const [progress, setProgress] = useState(0)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+  const [tasks, setTasks] = useState([])
+
+  useEffect(()=>{
+    (async()=>{
+      const t = await listTasks().catch(()=>[])
+      setTasks(t)
+    })()
+  },[])
+
+  function onPickFiles(e){
+    const list = Array.from(e.target.files || [])
+    const allowed = ['application/pdf','image/png','image/jpeg','text/plain']
+    const cleaned = list.filter(f => allowed.includes(f.type) && f.size <= 5*1024*1024)
+    setFiles(cleaned)
+  }
+
+  async function onSubmit(e){
+    e.preventDefault()
+    setError(''); setSuccess('')
+    if(!title || !description){ setError('Título y descripción son obligatorios'); return }
+    if(points < 0){ setError('Los puntos no pueden ser negativos'); return }
+
+    try{
+      setSaving(true)
+      // Simula upload
+      setProgress(0)
+      await new Promise(resolve=>{
+        let p = 0
+        const id = setInterval(()=>{
+          p += 15
+          setProgress(Math.min(p, 100))
+          if (p >= 100){ clearInterval(id); resolve() }
+        }, 120)
+      })
+
+      const payload = {
+        title,
+        description,
+        dueDate: dueDate || null,
+        points: Number(points),
+        attachments: files.map(f => ({ name:f.name, type:f.type, size:f.size }))
+      }
+      const saved = await createTask(payload)
+      setSuccess('Tarea enviada para revisión')
+      setTasks(prev => [saved, ...prev])
+
+      // reset
+      setTitle(''); setDescription(''); setDueDate(''); setPoints(10); setFiles([]); setProgress(0)
+    }catch(err){
+      setError(err.message || 'No se pudo registrar la tarea')
+    }finally{
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="container" style={{padding:0}}>
+      <div className="card" style={{marginBottom:16}}>
+        <h3 style={{marginBottom:8}}>Registrar Tarea</h3>
+        <form onSubmit={onSubmit}>
+          <label>Título *</label>
+          <input value={title} onChange={e=>setTitle(e.target.value)} placeholder="Ej: Capacitación de seguridad" />
+          <label>Descripción *</label>
+          <input value={description} onChange={e=>setDescription(e.target.value)} placeholder="Describe lo realizado…" />
+
+          <div className="row">
+            <div style={{flex:1}}>
+              <label>Fecha límite</label>
+              <input type="date" value={dueDate} onChange={e=>setDueDate(e.target.value)} />
+            </div>
+            <div style={{width:220}}>
+              <label>Puntos</label>
+              <input type="number" min="0" value={points} onChange={e=>setPoints(e.target.value)} />
+            </div>
+          </div>
+
+          <label>Evidencias (PDF/JPG/PNG/TXT, máx 5 MB c/u)</label>
+          <input type="file" multiple onChange={onPickFiles} />
+
+          {!!files.length && (
+            <div className="list" style={{marginTop:10}}>
+              {files.map((f,i)=>(
+                <div key={i} className="listItem">
+                  <span>{f.name}</span>
+                  <span style={{opacity:.7, fontSize:12}}>{(f.size/1024/1024).toFixed(2)} MB</span>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {saving || progress>0 ? (
+            <div className="progressBar" style={{marginTop:12}}>
+              <div className="progressInner" style={{width: `${progress}%`}} />
+            </div>
+          ) : null}
+
+          {error && <div className="error">{error}</div>}
+          {success && <div className="success">{success}</div>}
+
+          <button className="btn" style={{marginTop:12}} disabled={saving}>
+            {saving ? 'Enviando…' : 'Enviar para revisión'}
+          </button>
+        </form>
+      </div>
+
+      <div className="card">
+        <h3>Tus envíos recientes</h3>
+        {!tasks.length && <div style={{opacity:.7}}>Aún no has registrado tareas.</div>}
+        {tasks.map(t=>(
+          <div key={t.id} className="listItem">
+            <div>
+              <div style={{fontWeight:600}}>{t.title}</div>
+              <div style={{opacity:.7, fontSize:12}}>
+                {t.dueDate ? `Vence: ${t.dueDate}` : 'Sin fecha límite'} · {t.attachments?.length || 0} adjuntos
+              </div>
+            </div>
+            <div style={{display:'grid', justifyItems:'end'}}>
+              <span style={{opacity:.8}}>{t.points} pts</span>
+              <span style={{fontSize:12, opacity:.7}}>Estado: {t.status}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/Front/src/services/api.js
+++ b/Front/src/services/api.js
@@ -33,6 +33,14 @@ export async function getProfile(token) {
 // MOCK mode (sin backend) //
 function delay(ms){ return new Promise(r=>setTimeout(r, ms)) }
 const mockDBKey = 'trp_mock_users'
+const mockTasksKey = 'trp_mock_tasks'
+
+export async function createTask(payload){
+  return http('/api/tasks', { method: 'POST', data: payload })
+}
+export async function listTasks(){
+  return http('/api/tasks', { method: 'GET' })
+}
 
 async function mockHttp(path, { method, data, token }){
   await delay(400)
@@ -61,6 +69,24 @@ async function mockHttp(path, { method, data, token }){
     if (!user) throw new Error('Usuario no encontrado')
     const { password, ...safe } = user
     return safe
+  }
+
+  if (path === '/api/tasks' && method === 'POST') {
+    const tasks = JSON.parse(localStorage.getItem(mockTasksKey) || '[]')
+    const task = {
+      id: crypto.randomUUID(),
+      ...data,
+      createdAt: new Date().toISOString(),
+      status: 'ENVIADA' // Flujo: BORRADOR | ENVIADA | APROBADA | RECHAZADA
+    }
+    tasks.unshift(task)
+    localStorage.setItem(mockTasksKey, JSON.stringify(tasks))
+    return task
+  }
+
+  if (path === '/api/tasks' && method === 'GET') {
+    const tasks = JSON.parse(localStorage.getItem(mockTasksKey) || '[]')
+    return tasks
   }
 
   throw new Error('Ruta mock no implementada: ' + path)

--- a/Front/src/styles.css
+++ b/Front/src/styles.css
@@ -70,3 +70,12 @@ input:focus{box-shadow:0 0 0 6px var(--ring);border-color:var(--primary)}
 .listItem:hover{background:#10162b}
 .progressBar{height:10px;background:#0f1426;border:1px solid var(--border);border-radius:999px;overflow:hidden}
 .progressInner{height:100%;background:var(--success);width:60%}
+
+.badge{
+  display:inline-block;
+  padding:4px 8px;
+  border-radius:999px;
+  background:#0f1426;
+  border:1px solid var(--border);
+  font-size:12px;
+}


### PR DESCRIPTION
I added a simple task registration page and cleaned up the sidebar so it actually takes you to real screens. The task page has a straightforward form where you can add details and attach files, and you’ll see a quick progress bar while it uploads . The header updates its title based on where you are. Behind the scenes, I set up a basic fake API to save and list tasks in your browser so you can try it out without a backend. 