### PR TITLE
Move app to /app layout, enable sidebar nav, and add task upload page

### DIFF
--- a/Front/src/App.jsx
+++ b/Front/src/App.jsx
@@ -4,6 +4,8 @@ import Login from './pages/Login.jsx'
 import Register from './pages/Register.jsx'
 import Dashboard from './pages/Dashboard.jsx'
 import { AuthProvider } from './context/AuthContext.jsx'
+import ProtectedRoute from './components/ProtectedRoute.jsx'
+import TaskRegister from './pages/TaskRegister.jsx'
 
 export default function App() {
   return (
@@ -12,7 +14,10 @@ export default function App() {
         <Route path="/" element={<Navigate to="/login" />} />
         <Route path="/login" element={<div style={{padding:20}}><Login /></div>} />
         <Route path="/register" element={<div style={{padding:20}}><Register /></div>} />
-        <Route path="/dashboard" element={<div style={{padding:20}}><Dashboard /></div>} />
+        <Route path="/app" element={<ProtectedRoute />}>
+          <Route path="dashboard" element={<Dashboard />} />
+          <Route path="tareas/registro" element={<TaskRegister />} />
+        </Route>
         <Route path="*" element={<h2 style={{padding:24}}>404</h2>} />
       </Routes>
     </AuthProvider>

--- a/Front/src/components/Sidebar.jsx
+++ b/Front/src/components/Sidebar.jsx
@@ -24,13 +24,13 @@ export default function Sidebar(){
       </div>
 
       <nav style={{display:'grid',gap:6}}>
-        <NavLink to="/dashboard" className={({isActive}) => 'navItem' + (isActive ? ' active' : '')}>Dashboard</NavLink>
-        <a className="navItem" href="#" onClick={e=>e.preventDefault()}>Tareas</a>
-        <a className="navItem" href="#" onClick={e=>e.preventDefault()}>Metas</a>
-        <a className="navItem" href="#" onClick={e=>e.preventDefault()}>Recompensas</a>
-        <a className="navItem" href="#" onClick={e=>e.preventDefault()}>Historial de Canjes</a>
-        <a className="navItem" href="#" onClick={e=>e.preventDefault()}>Ranking</a>
-        <a className="navItem" href="#" onClick={e=>e.preventDefault()}>Usuarios</a>
+          {link('/app/dashboard', 'Dashboard')}
+        {link('/app/tareas/registro', 'Tareas')}
+        {link('/app/metas', 'Metas')}
+        {link('/app/recompensas', 'Recompensas')}
+        {link('/app/canjes', 'Historial de Canjes')}
+        {link('/app/ranking', 'Ranking')}
+        {link('/app/usuarios', 'Usuarios')}
       </nav>
 
       <div style={{marginTop:'auto'}}>

--- a/Front/src/pages/Login.jsx
+++ b/Front/src/pages/Login.jsx
@@ -11,7 +11,7 @@ export default function Login(){
   const [error,setError] = useState('')
   const navigate = useNavigate()
   const location = useLocation()
-  const from = location.state?.from?.pathname || '/dashboard'
+  const from = location.state?.from?.pathname || '/app/dashboard'
 
   useEffect(()=>{
     const saved = localStorage.getItem('trp_saved_email')
@@ -78,7 +78,7 @@ export default function Login(){
                   try{ await api.register({ name:'Usuario Demo', email:demoEmail, password:demoPass }) }catch{}
                   await login(demoEmail, demoPass)
                 }
-                navigate('/dashboard', { replace:true })
+                navigate('/app/dashboard', { replace:true })
               }catch{ setError('No se pudo entrar en modo demo') }
               finally{ setLoading(false) }
             }}

--- a/Front/src/pages/Register.jsx
+++ b/Front/src/pages/Register.jsx
@@ -21,7 +21,7 @@ export default function Register(){
     try{
       setLoading(true)
       await register({ name, email, password })
-      navigate('/dashboard', { replace:true })
+      navigate('/app/dashboard', { replace:true })
     }catch(err){
       setError(err.message || 'Error al crear usuario')
     }finally{


### PR DESCRIPTION
We (Pipe y Sebas) reorganized things so the main screens all live together and share the same sidebar and header, making navigation feel consistent wherever you go. I also added a simple page to register tasks where you can attach PDFs as proof, and the page title now updates based on where you are.